### PR TITLE
[CASL] Fix podspec validation issues.

### DIFF
--- a/CyndiLauper/CASLDocument.m
+++ b/CyndiLauper/CASLDocument.m
@@ -8,8 +8,8 @@
 
 #import "CASLDocument.h"
 
-#import <VOKCoreDataManager.h>
-#import <VOKKeyPathHelper.h>
+#import <Vokoder/VOKCoreDataManager.h>
+#import <VOKUtilities/VOKKeyPathHelper.h>
 
 #import "NSManagedObjectModel+CASL.h"
 

--- a/CyndiLauper/Document Serializers/Implementations/CASLDocumentSerializerJsonV1.m
+++ b/CyndiLauper/Document Serializers/Implementations/CASLDocumentSerializerJsonV1.m
@@ -8,8 +8,8 @@
 
 #import "CASLDocumentSerializerJsonV1.h"
 
+#import <Vokoder/VOKCoreDataManager.h>
 #import <VOKUtilities/VOKKeyPathHelper.h>
-#import <VOKCoreDataManager.h>
 
 #import "CASLDocument.h"
 

--- a/CyndiLauper/Document Serializers/Implementations/CASLDocumentSerializerZipV1.m
+++ b/CyndiLauper/Document Serializers/Implementations/CASLDocumentSerializerZipV1.m
@@ -9,7 +9,8 @@
 #import "CASLDocumentSerializerZipV1.h"
 
 #import <VOKUtilities/VOKKeyPathHelper.h>
-#import <zipzap.h>
+#import <zipzap/ZZArchive.h>
+#import <zipzap/ZZArchiveEntry.h>
 
 #import "NSFont+CASL.h"
 

--- a/TrueColors.xcodeproj/project.pbxproj
+++ b/TrueColors.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 				ADE0ACCCFF5660FFFA1801916F1C6D77 /* Sources */,
 				B444A59F07DCDB92799900ABEFC5942B /* Frameworks */,
 				6891E9A6BC25CD6B2D0C1AE085B91B84 /* Resources */,
-				70047CD69FF5FD5C9ECBCD1562BDEA3F /* Version Incrementing Run Script */,
+				2E6AB101082ADDD62D75FA6AC8528A1A /* Version Incrementing Run Script */,
 				E7DA9C7E2ABA3CD11FDE5BA923D37422 /* [CP] Embed Pods Frameworks */,
 				227456AD2B35DF4361993DA51E14B9B6 /* Sign Sparkle.framework */,
 				21ECCAA10976C6E5465F27034CED74F5 /* [CP] Copy Pods Resources */,
@@ -629,7 +629,7 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PROJECT_DIR}/util/mogenerator.sh\"";
 		};
-		70047CD69FF5FD5C9ECBCD1562BDEA3F /* Version Incrementing Run Script */ = {
+		2E6AB101082ADDD62D75FA6AC8528A1A /* Version Incrementing Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -641,7 +641,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Update build number with number of git commits\nbuildNumber=$(git rev-list HEAD --count)\necho \"Updating build number to $buildNumber\"\n/usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $buildNumber\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\nbaseVersion=$(/usr/libexec/PlistBuddy -c \"Print :TRUBaseVersionNumber\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\")\n/usr/libexec/PlistBuddy -c \"Set :CFBundleShortVersionString $baseVersion ($buildNumber)\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"";
+			shellScript = "\"${SRCROOT}/util/set_version_number.sh\"";
 		};
 		7B4F25A76B5F05527B4CBBF36D6944FA /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/util/set_version_number.sh
+++ b/util/set_version_number.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Update the Info.plist build number with number of git commits (adjusted by 1000 to move past old build numbers)
+buildNumber=$((1000 + $(git rev-list HEAD --count))) \
+    || exit 1
+echo "note: Updating build number to ${buildNumber}..."
+
+# Update the Info.plist build number with number of git commits
+/usr/libexec/PlistBuddy \
+    -c "Set CFBundleVersion ${buildNumber}" \
+    "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" \
+    || exit 1
+
+# Update the build number in the dsym's info.plist if it exists
+# (prevents potential version mismatches with the dsym)
+if [[ -e "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist" ]]; then
+    /usr/libexec/PlistBuddy \
+        -c "Set CFBundleVersion ${buildNumber}" \
+        "${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist" \
+        || exit 1
+fi
+
+# Update the short version string
+baseVersion=$(/usr/libexec/PlistBuddy -c "Print :TRUBaseVersionNumber" "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}")
+/usr/libexec/PlistBuddy \
+    -c "Set :CFBundleShortVersionString ${baseVersion} (${buildNumber})" \
+    "${TARGET_BUILD_DIR}/${INFOPLIST_PATH}" \
+    || exit 1
+
+echo "note: Done."


### PR DESCRIPTION
- [CASL] Use the full path for library imports so that podspec validation will work.
- Use a standalone file for build numbering script.
- Offset TrueColors build numbers by 1000 to move them past pre-existing build numbers.

@vokal/ios-developers Review please?